### PR TITLE
Fix issue #29 (bug in status_changed event)

### DIFF
--- a/jira/mapping/mapper.go
+++ b/jira/mapping/mapper.go
@@ -2,6 +2,7 @@ package mapping
 
 import (
 	"log"
+	"sort"
 	"time"
 
 	extJira "github.com/andygrunwald/go-jira"
@@ -60,7 +61,13 @@ func (m *Mapper) IssueEventsFromIssue(i *extJira.Issue) []store.IssueEvent {
 	hasChangelogOnStatus := false
 	hasChangelogOnAssignee := false
 	if i.Changelog != nil {
-		for _, h := range i.Changelog.Histories {
+		for k := range i.Changelog.Histories {
+			// We implement the loop using the index (k) to loop in reverse
+			// order. Histories returned by Jira API are sorted by time
+			// *descending* but the implementation is simpler if we
+			// process them in *ascending* order.
+			h := i.Changelog.Histories[len(i.Changelog.Histories)-k-1]
+
 			for _, cli := range h.Items {
 				switch cli.Field {
 				case "status":
@@ -153,6 +160,7 @@ func (m *Mapper) IssueEventsFromIssue(i *extJira.Issue) []store.IssueEvent {
 		})
 	}
 
+	sort.Sort(store.IssueEventsByTime(issueEvents))
 	return issueEvents
 }
 

--- a/jira/mapping/mapper_test.go
+++ b/jira/mapping/mapper_test.go
@@ -97,8 +97,8 @@ func TestIssueEventsFromIssue(t *testing.T) {
 			nil,
 			"Open",
 			[]changelogMockDef{
-				changelogMockDef{"status", "Open", "In Dev", refTime.Add(1 * time.Hour)},
 				changelogMockDef{"assignee", "InitialAssignee", "ChangedAssignee", refTime.Add(2 * time.Hour)},
+				changelogMockDef{"status", "Open", "In Dev", refTime.Add(1 * time.Hour)},
 			},
 		}
 		i := mockIssue(def)
@@ -161,8 +161,8 @@ func TestIssueEventsFromIssue(t *testing.T) {
 			nil,
 			"Open",
 			[]changelogMockDef{
-				changelogMockDef{"status", "Open", "In Dev", refTime.Add(1 * time.Hour)},
 				changelogMockDef{"status", "In Dev", "In Review", refTime.Add(2 * time.Hour)},
+				changelogMockDef{"status", "Open", "In Dev", refTime.Add(1 * time.Hour)},
 			},
 		}
 		i := mockIssue(def)

--- a/store/store.go
+++ b/store/store.go
@@ -76,3 +76,11 @@ func (ie IssueEvent) String() string {
 	}
 	return fmt.Sprintf("<IssueEvent:%s `%s` -> `%s`: time=%s author=%s issueKey=%s>", ie.EventKind, from, to, ie.EventTime, ie.EventAuthor, ie.IssueKey)
 }
+
+// IssueEventsByTime implements sort.Interface for []IssueEvent based on
+// the EventTime field.
+type IssueEventsByTime []IssueEvent
+
+func (a IssueEventsByTime) Len() int           { return len(a) }
+func (a IssueEventsByTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a IssueEventsByTime) Less(i, j int) bool { return a[i].EventTime.Before(a[j].EventTime) }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -2,12 +2,28 @@ package store_test
 
 import (
 	"database/sql/driver"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/rchampourlier/kaizenizer-source-jira/store"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
+
+func TestStore_IssueEventsByTime_sort(t *testing.T) {
+	refTime := time.Now()
+	refTimePlus1Hour := refTime.Add(time.Hour)
+
+	evt1 := store.IssueEvent{EventTime: refTime}
+	evt2 := store.IssueEvent{EventTime: refTimePlus1Hour}
+	evts := []store.IssueEvent{evt2, evt1}
+
+	sort.Sort(store.IssueEventsByTime(evts))
+
+	if evts[0].EventTime != refTime {
+		t.Errorf("expected event at index 0 to have time %s, got %s", refTime, evts[0].EventTime)
+	}
+}
 
 func TestPGStore_ReplaceIssueStateAndEvents(t *testing.T) {
 	db, mock, err := sqlmock.New()


### PR DESCRIPTION
- Jira returns changelog histories sorted by time descending
- The tests mocked issues with changelog histories sorted by
  time ascending instead. The tests were wrong and masking
  the bug. The tests have been updated to match Jira API.
- The bug was fixed in `jira/mapping/mapper.go` by changing
  the order of processing histories.

Fixes #29 
